### PR TITLE
fix: Correct workflow outputs and variable handling

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -44,10 +44,10 @@ inputs:
 outputs:
   issue-url:
     description: URL of the created or existing issue
-    value: ${{ steps.verify-issue.outputs.issue_url }}
+    value: ${{ steps.verify-issue.outputs.issue-url }}
   issue-number:
     description: Number of the created or existing issue
-    value: ${{ steps.verify-issue.outputs.issue_number }}
+    value: ${{ steps.verify-issue.outputs.issue-number }}
 
 runs:
   using: composite


### PR DESCRIPTION
This commit resolves a series of bugs that prevented the CI workflow from correctly creating and using issue numbers. The changes include:

- Corrects a YAML syntax error where a 'value' property was incorrectly placed at the step level, causing the workflow to fail to parse.
- Refines the logical flow for handling issue IDs to correctly account for all possible scenarios (e.g., when no issue is found).
- Standardizes variable naming to use hyphens (-) in YAML and underscores (_) for shell scripts, ensuring outputs are correctly passed between steps.